### PR TITLE
Add default producer/consumer interceptor

### DIFF
--- a/src/main/java/io/github/majusko/pulsar/PulsarAutoConfiguration.java
+++ b/src/main/java/io/github/majusko/pulsar/PulsarAutoConfiguration.java
@@ -1,13 +1,13 @@
 package io.github.majusko.pulsar;
 
 import com.google.common.base.Strings;
+import io.github.majusko.pulsar.consumer.DefaultConsumerInterceptor;
 import io.github.majusko.pulsar.error.exception.ClientInitException;
+import io.github.majusko.pulsar.producer.DefaultProducerInterceptor;
 import io.github.majusko.pulsar.properties.ConsumerProperties;
 import io.github.majusko.pulsar.properties.PulsarProperties;
-import org.apache.pulsar.client.api.AuthenticationFactory;
-import org.apache.pulsar.client.api.ClientBuilder;
-import org.apache.pulsar.client.api.PulsarClient;
-import org.apache.pulsar.client.api.PulsarClientException;
+import org.apache.pulsar.client.api.*;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.apache.pulsar.client.impl.auth.oauth2.AuthenticationFactoryOAuth2;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
@@ -28,6 +28,18 @@ public class PulsarAutoConfiguration {
 
     public PulsarAutoConfiguration(PulsarProperties pulsarProperties) {
         this.pulsarProperties = pulsarProperties;
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ProducerInterceptor producerInterceptor(){
+        return new DefaultProducerInterceptor();
+    }
+
+    @Bean
+    @ConditionalOnMissingBean
+    public ConsumerInterceptor consumerInterceptor(){
+        return new DefaultConsumerInterceptor();
     }
 
     @Bean

--- a/src/main/java/io/github/majusko/pulsar/consumer/DefaultConsumerInterceptor.java
+++ b/src/main/java/io/github/majusko/pulsar/consumer/DefaultConsumerInterceptor.java
@@ -9,10 +9,6 @@ import org.slf4j.LoggerFactory;
 
 import java.util.Set;
 
-/**
- * @author crossoverJie
- * Date: 2022/3/10 00:32
- */
 public class DefaultConsumerInterceptor<T> implements ConsumerInterceptor<T> {
     Logger logger = LoggerFactory.getLogger(DefaultConsumerInterceptor.class);
     @Override

--- a/src/main/java/io/github/majusko/pulsar/consumer/DefaultConsumerInterceptor.java
+++ b/src/main/java/io/github/majusko/pulsar/consumer/DefaultConsumerInterceptor.java
@@ -1,0 +1,65 @@
+package io.github.majusko.pulsar.consumer;
+
+import org.apache.pulsar.client.api.Consumer;
+import org.apache.pulsar.client.api.ConsumerInterceptor;
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Set;
+
+/**
+ * @author crossoverJie
+ * Date: 2022/3/10 00:32
+ */
+public class DefaultConsumerInterceptor<T> implements ConsumerInterceptor<T> {
+    Logger logger = LoggerFactory.getLogger(DefaultConsumerInterceptor.class);
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public Message<T> beforeConsume(Consumer<T> consumer, Message<T> message) {
+        logger.info("[Pulsar consumer log:BeforeConsume] ProducerName[{}], ConsumerName:[{}], Topic:[{}], msgID:[{}], Payload:[{}],"+
+                " MessageKey:[{}], PublishTime:[{}], RedeliveryCount:[{}], GetReplicatedFrom:[{}]",
+                message.getProducerName(), consumer.getConsumerName(), message.getTopicName(), message.getMessageId(), new String(message.getData()),
+                message.getKey(), message.getPublishTime(), message.getRedeliveryCount(), message.getReplicatedFrom());
+
+        return message;
+    }
+
+    @Override
+    public void onAcknowledge(Consumer<T> consumer, MessageId messageId, Throwable exception) {
+        if (exception != null){
+            logger.info("[Pulsar consumer log:OnAcknowledge] ConsumerName:[{}], msgID:[{}], exception:[{}]", consumer.getConsumerName(), messageId, exception);
+            return;
+        }
+        logger.info("[Pulsar consumer log:OnAcknowledge] ConsumerName:[{}], msgID:[{}]", consumer.getConsumerName(), messageId);
+    }
+
+    @Override
+    public void onAcknowledgeCumulative(Consumer<T> consumer, MessageId messageId, Throwable exception) {
+        if (exception != null){
+            logger.info("[Pulsar consumer log:OnAcknowledgeCumulative] ConsumerName:[{}], msgID:[{}], exception:[{}]", consumer.getConsumerName(), messageId, exception);
+            return;
+        }
+        logger.info("[Pulsar consumer log:OnAcknowledgeCumulative] ConsumerName:[{}], msgID:[{}]", consumer.getConsumerName(), messageId);
+    }
+
+    @Override
+    public void onNegativeAcksSend(Consumer<T> consumer, Set<MessageId> messageIds) {
+        logger.info("[Pulsar consumer log:OnNegativeAcksSend] ConsumerName:[{}], msgID:[{}]", consumer.getConsumerName() ,messageIds);
+    }
+
+    @Override
+    public void onAckTimeoutSend(Consumer<T> consumer, Set<MessageId> messageIds) {
+        logger.info("[Pulsar consumer log:OnAckTimeoutSend] ConsumerName:[{}], msgID:[{}]", consumer.getConsumerName() ,messageIds);
+    }
+
+    @Override
+    public void onPartitionsChange(String topicName, int partitions) {
+        logger.info("[Pulsar consumer log:OnPartitionsChange] Topic:[{}], Partitions:[{}]", topicName, partitions);
+    }
+}

--- a/src/main/java/io/github/majusko/pulsar/producer/DefaultProducerInterceptor.java
+++ b/src/main/java/io/github/majusko/pulsar/producer/DefaultProducerInterceptor.java
@@ -7,10 +7,6 @@ import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/**
- * @author crossoverJie
- * Date: 2022/2/14 16:48
- */
 public class DefaultProducerInterceptor implements ProducerInterceptor {
     Logger logger = LoggerFactory.getLogger(DefaultProducerInterceptor.class);
 

--- a/src/main/java/io/github/majusko/pulsar/producer/DefaultProducerInterceptor.java
+++ b/src/main/java/io/github/majusko/pulsar/producer/DefaultProducerInterceptor.java
@@ -1,0 +1,56 @@
+package io.github.majusko.pulsar.producer;
+
+import org.apache.pulsar.client.api.Message;
+import org.apache.pulsar.client.api.MessageId;
+import org.apache.pulsar.client.api.Producer;
+import org.apache.pulsar.client.api.interceptor.ProducerInterceptor;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * @author crossoverJie
+ * Date: 2022/2/14 16:48
+ */
+public class DefaultProducerInterceptor implements ProducerInterceptor {
+    Logger logger = LoggerFactory.getLogger(DefaultProducerInterceptor.class);
+
+    @Override
+    public void close() {
+
+    }
+
+    @Override
+    public boolean eligible(Message message) {
+        return true;
+    }
+
+    @Override
+    public Message beforeSend(Producer producer, Message message) {
+        logger.info("[Pulsar producer log:BeforeSend] ProducerName:[{}], Topic:[{}], Payload:[{}]",
+                producer.getProducerName(),
+                producer.getTopic(),
+                new String(message.getData()));
+        return message;
+    }
+
+    /**
+     * This method will generally execute in the background I/O thread, so the
+     * implementation should be reasonably fast. Otherwise, sending of messages
+     * from other threads could be delayed.
+     */
+    @Override
+    public void onSendAcknowledgement(Producer producer, Message message, MessageId msgId, Throwable exception) {
+        if (exception != null) {
+            logger.error("[Pulsar producer log:OnSendAcknowledgement] Producer:[{}], Topic:[{}], Payload:[{}], msgID:[{}], exception:[{}]",
+                    producer.getProducerName(), producer.getTopic(), message.getValue().toString(), msgId.toString(), exception);
+            return;
+        }
+        logger.info("[Pulsar producer log:OnSendAcknowledgement] Producer:[{}], Topic:[{}], Payload:[{}], msgID:[{}]",
+                producer.getProducerName(), producer.getTopic(), new String(message.getData()), msgId.toString());
+    }
+
+    @Override
+    public void onPartitionsChange(String topicName, int partitions) {
+        logger.info("[Pulsar producer log:OnPartitionsChange] Topic:[{}], Partitions:[{}]", topicName, partitions);
+    }
+}


### PR DESCRIPTION
This is a great project.

We need to record a log of production and consumption when using pulsar, so we added this feature.

Custom interceptors are also supported.

```java
@Component
@Slf4j
public class PulsarConsumerInterceptor extends DefaultConsumerInterceptor {
    @Override
    public Message beforeConsume(Consumer consumer, Message message) {
        log.info("do something");
        return super.beforeConsume(consumer, message);
    }
}

@Component
@Slf4j
public class PulsarProducerInterceptor extends DefaultProducerInterceptor {

    @Override
    public Message beforeSend(Producer producer, Message message) {
        super.beforeSend(producer, message);
        log.info("do something");
        return message;
    }

    @Override
    public void onSendAcknowledgement(Producer producer, Message message, MessageId msgId, Throwable exception) {
        super.onSendAcknowledgement(producer, message, msgId, exception);
    }
}
```