### PR TITLE
feat: add chance to specify namespace for consumer and producer

### DIFF
--- a/src/main/java/io/github/majusko/pulsar/collector/ProducerHolder.java
+++ b/src/main/java/io/github/majusko/pulsar/collector/ProducerHolder.java
@@ -2,11 +2,14 @@ package io.github.majusko.pulsar.collector;
 
 import io.github.majusko.pulsar.constant.Serialization;
 
+import java.util.Optional;
+
 public class ProducerHolder {
 
     private final String topic;
     private final Class<?> clazz;
     private final Serialization serialization;
+    private String namespace;
 
     public ProducerHolder(String topic, Class<?> clazz, Serialization serialization) {
         this.topic = topic;
@@ -14,8 +17,17 @@ public class ProducerHolder {
         this.serialization = serialization;
     }
 
+    public ProducerHolder(String topic, Class<?> clazz, Serialization serialization, String namespace) {
+        this(topic, clazz, serialization);
+        this.namespace =  namespace;
+    }
+
     public String getTopic() {
         return topic;
+    }
+
+    public Optional<String> getNamespace() {
+        return Optional.ofNullable(namespace);
     }
 
     public Class<?> getClazz() {

--- a/src/main/java/io/github/majusko/pulsar/consumer/ConsumerAggregator.java
+++ b/src/main/java/io/github/majusko/pulsar/consumer/ConsumerAggregator.java
@@ -9,7 +9,7 @@ import io.github.majusko.pulsar.error.exception.ConsumerInitException;
 import io.github.majusko.pulsar.properties.ConsumerProperties;
 import io.github.majusko.pulsar.properties.PulsarProperties;
 import io.github.majusko.pulsar.utils.SchemaUtils;
-import io.github.majusko.pulsar.service.UrlBuildService;
+import io.github.majusko.pulsar.utils.UrlBuildService;
 import org.apache.pulsar.client.api.*;
 import org.springframework.boot.context.event.ApplicationReadyEvent;
 import org.springframework.context.EmbeddedValueResolverAware;
@@ -74,7 +74,7 @@ public class ConsumerAggregator implements EmbeddedValueResolverAware {
                     holder.getAnnotation().clazz()))
                 .consumerName(urlBuildService.buildPulsarConsumerName(consumerName, generatedConsumerName))
                 .subscriptionName(urlBuildService.buildPulsarSubscriptionName(subscriptionName, generatedConsumerName))
-                .topic(urlBuildService.buildTopicUrl(topicName,namespace))
+                .topic(urlBuildService.buildTopicUrl(topicName, namespace))
                 .subscriptionType(subscriptionType)
                 .subscriptionInitialPosition(holder.getAnnotation().initialPosition())
                 .messageListener((consumer, msg) -> {

--- a/src/main/java/io/github/majusko/pulsar/producer/ProducerFactory.java
+++ b/src/main/java/io/github/majusko/pulsar/producer/ProducerFactory.java
@@ -2,31 +2,41 @@ package io.github.majusko.pulsar.producer;
 
 import io.github.majusko.pulsar.annotation.PulsarProducer;
 import io.github.majusko.pulsar.constant.Serialization;
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Optional;
 
 @PulsarProducer
 public class ProducerFactory implements PulsarProducerFactory {
-
-    private final Map<String, ImmutablePair<Class<?>, Serialization>> topics = new HashMap<>();
+    private final Map<String, ImmutableTriple<Class<?>, Serialization, Optional<String>>> topics = new HashMap<>();
 
     public ProducerFactory addProducer(String topic) {
         return addProducer(topic, byte[].class, Serialization.BYTE);
     }
 
     public ProducerFactory addProducer(String topic, Class<?> clazz) {
-        topics.put(topic, new ImmutablePair<>(clazz, Serialization.JSON));
+        topics.put(topic, new ImmutableTriple<>(clazz, Serialization.JSON, Optional.empty()));
         return this;
     }
 
     public ProducerFactory addProducer(String topic, Class<?> clazz, Serialization serialization) {
-        topics.put(topic, new ImmutablePair<>(clazz, serialization));
+        topics.put(topic, new ImmutableTriple<>(clazz, serialization, Optional.empty()));
         return this;
     }
 
-    public Map<String, ImmutablePair<Class<?>, Serialization>> getTopics() {
+    public ProducerFactory addProducer(String topic, String namespace, Class<?> clazz, Serialization serialization) {
+        topics.put(topic, new ImmutableTriple<>(clazz, serialization, Optional.of(namespace)));
+        return this;
+    }
+
+    public ProducerFactory addProducer(String topic, String namespace, Class<?> clazz) {
+        topics.put(topic, new ImmutableTriple<>(clazz, Serialization.JSON, Optional.of(namespace)));
+        return this;
+    }
+
+    public Map<String, ImmutableTriple<Class<?>, Serialization, Optional<String>>> getTopics() {
         return topics;
     }
 }

--- a/src/main/java/io/github/majusko/pulsar/producer/PulsarProducerFactory.java
+++ b/src/main/java/io/github/majusko/pulsar/producer/PulsarProducerFactory.java
@@ -1,10 +1,11 @@
 package io.github.majusko.pulsar.producer;
 
 import io.github.majusko.pulsar.constant.Serialization;
-import org.apache.commons.lang3.tuple.ImmutablePair;
+import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 import java.util.Map;
+import java.util.Optional;
 
 public interface PulsarProducerFactory {
-    Map<String, ImmutablePair<Class<?>, Serialization>> getTopics();
+    Map<String, ImmutableTriple<Class<?>, Serialization, Optional<String>>> getTopics();
 }

--- a/src/main/java/io/github/majusko/pulsar/utils/UrlBuildService.java
+++ b/src/main/java/io/github/majusko/pulsar/utils/UrlBuildService.java
@@ -42,6 +42,14 @@ public class UrlBuildService {
             "/" + topic;
     }
 
+    public String buildTopicUrl(String topic, String namespace) {
+        if (Strings.isNullOrEmpty(namespace)) {
+            return buildTopicUrl(topic);
+        }
+
+        return DEFAULT_PERSISTENCE + "://" + pulsarProperties.getTenant() + "/" + namespace + "/" + topic;
+    }
+
     public String buildPulsarConsumerName(String customConsumerName, String generatedConsumerName) {
         if (Strings.isNullOrEmpty(customConsumerName)) {
             return CONSUMER_NAME_PREFIX + consumerNameDelimiter + generatedConsumerName;

--- a/src/test/java/io/github/majusko/pulsar/TestConsumers.java
+++ b/src/test/java/io/github/majusko/pulsar/TestConsumers.java
@@ -31,6 +31,7 @@ public class TestConsumers {
     public AtomicBoolean customConsumerTestReceived = new AtomicBoolean(false);
     public AtomicInteger failTwiceRetryCount = new AtomicInteger(0);
     public AtomicInteger topicOverflowDueToExceptionRetryCount = new AtomicInteger(0);
+    public AtomicBoolean customConsumerNamespaceReceived = new AtomicBoolean(false);
 
     public static final String CUSTOM_CONSUMER_NAME = "custom-consumer-name";
     public static final String CUSTOM_SUBSCRIPTION_NAME= "custom-subscription-name";
@@ -38,6 +39,7 @@ public class TestConsumers {
     public static final String CUSTOM_SUB_AND_CONSUMER_TOPIC = "custom-sub-and-consumer";
     public static final String SHARED_SUB_TEST = "shared-sub-consumer";
     public static final String EXCLUSIVE_SUB_TEST = "exclusive-sub-consumer";
+    public static final String CUSTOM_NAMESPACE_TOPIC_TEST = "default";
 
     @PulsarConsumer(topic = "topic-one", clazz = MyMsg.class, serialization = Serialization.JSON)
     public void topicOneListener(MyMsg myMsg) {
@@ -177,5 +179,16 @@ public class TestConsumers {
         Assertions.assertNotNull(myMsg);
         Assertions.assertEquals(PulsarJavaSpringBootStarterApplicationTests.VALIDATION_STRING, myMsg.getData());
         subscribeToSharedTopicSubscription.set(true);
+    }
+
+    @PulsarConsumer(
+        topic = CUSTOM_NAMESPACE_TOPIC_TEST,
+        clazz = MyMsg.class,
+        subscriptionType = SubscriptionType.Exclusive,
+        namespace = "default")
+    public void customConsumerNamespace(MyMsg myMsg) {
+        Assertions.assertNotNull(myMsg);
+        Assertions.assertEquals(PulsarJavaSpringBootStarterApplicationTests.VALIDATION_STRING, myMsg.getData());
+        customConsumerNamespaceReceived.set(true);
     }
 }

--- a/src/test/java/io/github/majusko/pulsar/TestProducerConfiguration.java
+++ b/src/test/java/io/github/majusko/pulsar/TestProducerConfiguration.java
@@ -27,6 +27,7 @@ public class TestProducerConfiguration {
             .addProducer("topic-proto", ProtoMsg.class, Serialization.PROTOBUF)
             .addProducer("topic-deliver-to-dead-letter", MyMsg.class)
             .addProducer("${my.custom.topic.name}", MyMsg.class)
+            .addProducer(TestConsumers.CUSTOM_NAMESPACE_TOPIC_TEST, "default", MyMsg.class)
             .addProducer(TestConsumers.CUSTOM_SUB_AND_CONSUMER_TOPIC, MyMsg.class)
             .addProducer(TestConsumers.SHARED_SUB_TEST, MyMsg.class)
             .addProducer(TestConsumers.EXCLUSIVE_SUB_TEST, MyMsg.class)


### PR DESCRIPTION
Adding the chance to specify a custom namespace for a Consumer and a Producer. 
This PR should enable having a single project and a single process instance with multiple consumers on different namespaces since actually, just a single namespace can specified through application properties.

NOTE: The idea was to enable custom namespace on Consumers only. I've added it also on Producer to enable integration tests since the test producers were enabled to publish only on the application.properties namespace. 

Unfortunately, since we are using TestContainer and the Pulsar docker image offers only the "default" namespace, I cannot specify a custom namespace other than "default", and these tests are not so meaningful. 
A more meaningful test should be creating a new namespace called "custom" and trying to publish and consume on that namespace. If you have a suggestion on how to configure the Pulsar container to add a new namespace they are appreciated.
