### PR TITLE
support metrics

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -35,6 +35,16 @@
 		</dependency>
 
 		<dependency>
+			<groupId>io.micrometer</groupId>
+			<artifactId>micrometer-registry-prometheus</artifactId>
+		</dependency>
+
+		<dependency>
+			<groupId>org.springframework.boot</groupId>
+			<artifactId>spring-boot-starter-actuator</artifactId>
+		</dependency>
+
+		<dependency>
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-configuration-processor</artifactId>
 			<scope>compile</scope>

--- a/src/main/java/io/github/majusko/pulsar/metrics/Metrics.java
+++ b/src/main/java/io/github/majusko/pulsar/metrics/Metrics.java
@@ -1,0 +1,91 @@
+package io.github.majusko.pulsar.metrics;
+
+
+import com.google.common.collect.Sets;
+import io.github.majusko.pulsar.properties.PulsarProperties;
+import io.github.majusko.pulsar.utils.UrlBuildService;
+import io.micrometer.core.instrument.MeterRegistry;
+import io.micrometer.core.instrument.Tag;
+import io.micrometer.core.instrument.Tags;
+
+import java.time.Duration;
+import java.util.Set;
+
+public class Metrics {
+    private static MeterRegistry meterRegistry;
+    private static PulsarProperties pulsarProperties;
+    private static UrlBuildService urlBuildService;
+
+    private Metrics() {
+    }
+
+    static void setMetrics(MeterRegistry meterRegistry, PulsarProperties pulsarProperties, UrlBuildService urlBuildService) {
+        Metrics.meterRegistry = meterRegistry;
+        Metrics.pulsarProperties = pulsarProperties;
+        Metrics.urlBuildService = urlBuildService;
+    }
+
+    private static void increment(String name, String... tags) {
+        meterRegistry.counter(name, buildCommonTags().and(tags)).increment();
+    }
+
+    private static void incrementCount(String name, double count, String... tags) {
+        meterRegistry.counter(name, buildCommonTags().and(tags)).increment(count);
+    }
+
+
+    public static void producerOpened(String topic) {
+        topic = urlBuildService.buildTopicUrl(topic);
+        increment("pulsar_client_producers_opened", "topic", topic);
+    }
+
+    public static void producerPendingMessage(String topic) {
+        increment("pulsar_client_producer_pending_messages", "topic", topic);
+    }
+
+    public static void producerPublishedMessage(String topic) {
+        increment("pulsar_client_producer_published_messages", "topic", topic);
+    }
+
+    public static void producerBytesPublished(String topic, double count) {
+        incrementCount("pulsar_client_producer_bytes_published", count, "topic", topic);
+    }
+
+
+    public static void consumersOpened(String topic) {
+        topic = urlBuildService.buildTopicUrl(topic);
+        increment("pulsar_client_consumers_opened", "topic", topic);
+    }
+
+    public static void acksCounter(String topic) {
+        increment("pulsar_client_consumer_acks", "topic", topic);
+    }
+
+    public static void acksTimeoutCounter(String topic) {
+        increment("pulsar_client_consumer_acks_timeout", "topic", topic);
+    }
+
+    public static void bytesReceived(String topic, double count) {
+        incrementCount("pulsar_client_consumer_bytes_received", count, "topic", topic);
+    }
+
+    public static void consumerSuccess(String topic, Duration duration) {
+        recordTimer("pulsar_client_consumer_status", duration, "status", "success", "topic", topic);
+    }
+
+    public static void consumerFail(String topic) {
+        increment("pulsar_client_consumer_status", "status", "fail", "topic", topic);
+    }
+
+    public static void recordTimer(String name, Duration duration, String... tags) {
+        meterRegistry.timer(name, buildCommonTags().and(tags)).record(duration);
+    }
+
+    private static Tags buildCommonTags() {
+        Set<Tag> tagSet = Sets.newHashSet();
+        tagSet.add(Tag.of("client", "Java"));
+        tagSet.add(Tag.of("pulsar_namespace", Metrics.pulsarProperties.getNamespace()));
+        tagSet.add(Tag.of("pulsar_tenant", Metrics.pulsarProperties.getTenant()));
+        return Tags.of(tagSet);
+    }
+}

--- a/src/main/java/io/github/majusko/pulsar/metrics/MetricsConfig.java
+++ b/src/main/java/io/github/majusko/pulsar/metrics/MetricsConfig.java
@@ -1,0 +1,27 @@
+package io.github.majusko.pulsar.metrics;
+
+
+import io.github.majusko.pulsar.properties.PulsarProperties;
+import io.github.majusko.pulsar.utils.UrlBuildService;
+import io.micrometer.core.instrument.MeterRegistry;
+import org.springframework.context.annotation.Configuration;
+
+import javax.annotation.PostConstruct;
+import javax.annotation.Resource;
+
+@Configuration
+public class MetricsConfig {
+    @Resource
+    private MeterRegistry meterRegistry;
+
+    @Resource
+    private PulsarProperties pulsarProperties;
+
+    @Resource
+    private UrlBuildService urlBuildService;
+
+    @PostConstruct
+    private void init() {
+        Metrics.setMetrics(meterRegistry, pulsarProperties, urlBuildService);
+    }
+}

--- a/src/main/java/io/github/majusko/pulsar/producer/DefaultProducerInterceptor.java
+++ b/src/main/java/io/github/majusko/pulsar/producer/DefaultProducerInterceptor.java
@@ -1,5 +1,6 @@
 package io.github.majusko.pulsar.producer;
 
+import io.github.majusko.pulsar.metrics.Metrics;
 import org.apache.pulsar.client.api.Message;
 import org.apache.pulsar.client.api.MessageId;
 import org.apache.pulsar.client.api.Producer;
@@ -26,6 +27,7 @@ public class DefaultProducerInterceptor implements ProducerInterceptor {
         logger.debug("[Pulsar producer log:BeforeSend] ProducerName:[{}], Topic:[{}]",
             producer.getProducerName(),
             producer.getTopic());
+        Metrics.producerPendingMessage(producer.getTopic());
         return message;
     }
 
@@ -38,6 +40,8 @@ public class DefaultProducerInterceptor implements ProducerInterceptor {
         }
         logger.debug("[Pulsar producer log:OnSendAcknowledgement] Producer:[{}], Topic:[{}] msgID:[{}]",
             producer.getProducerName(), producer.getTopic(), msgId.toString());
+        Metrics.producerPublishedMessage(producer.getTopic());
+        Metrics.producerBytesPublished(producer.getTopic(), message.getData().length);
     }
 
     @Override

--- a/src/main/java/io/github/majusko/pulsar/producer/ProducerFactory.java
+++ b/src/main/java/io/github/majusko/pulsar/producer/ProducerFactory.java
@@ -2,6 +2,7 @@ package io.github.majusko.pulsar.producer;
 
 import io.github.majusko.pulsar.annotation.PulsarProducer;
 import io.github.majusko.pulsar.constant.Serialization;
+import io.github.majusko.pulsar.metrics.Metrics;
 import org.apache.commons.lang3.tuple.ImmutableTriple;
 
 import java.util.HashMap;
@@ -36,7 +37,9 @@ public class ProducerFactory implements PulsarProducerFactory {
         return this;
     }
 
+    @Override
     public Map<String, ImmutableTriple<Class<?>, Serialization, Optional<String>>> getTopics() {
+        topics.keySet().forEach(Metrics::producerOpened);
         return topics;
     }
 }


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/15684156/185542409-78d39c74-f89d-4a52-bc9c-c35a43718574.png)

Reference to the [Go SDK](https://github.com/apache/pulsar-client-go/blob/master/pulsar/internal/metrics.go) implementation.

Monitor pulsar status on the application side using Prometheus and Grafana.

Some of the data is implemented through interceptors, so need to open the interceptor configuration. 

```properties
pulsar.allow-interceptor=true
```